### PR TITLE
Update Copilot setup workflow for project environment

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,9 +1,7 @@
-name: "copilot-setup-steps"
+name: "Copilot Setup Steps"
 
-# Automatically run the setup steps when they are changed
-# Allows for streamlined validation,
-# and allow manual testing through the repository's "Actions" tab
-
+# Automatically run the setup steps when they change for validation and allow
+# manual execution from the Actions tab.
 on:
   workflow_dispatch:
   push:
@@ -14,28 +12,28 @@ on:
       - .github/workflows/copilot-setup-steps.yml
 
 jobs:
-  # The job MUST be called `copilot-setup-steps`
-  # otherwise it will not be picked up by Copilot.
+  # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
   copilot-setup-steps:
     runs-on: ubuntu-latest
 
-    # Permissions set just for the setup steps
-    # Copilot has permissions to its branch
-    
+    # Use the minimal permissions required for the setup steps.
     permissions:
-      # To allow us to clone the repo for setup
       contents: read
 
-    # The setup steps - install Node.js and project dependencies
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
-          cache: "yarn"
+          node-version: '22'
+          cache: yarn
+          cache-dependency-path: |
+            yarn.lock
 
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --frozen-lockfile
+
+      - name: Build the application
+        run: yarn build


### PR DESCRIPTION
## Summary
- refresh the Copilot setup workflow to align with the recommended structure
- configure Node.js 22 with yarn caching and frozen-lockfile installs
- add a build step so Copilot has compiled artifacts available when it starts

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6914499535608326b87914de8c06c89f)